### PR TITLE
roll dice setup to handle multiple options for dice as well as default

### DIFF
--- a/src/bot-command-handlers.js
+++ b/src/bot-command-handlers.js
@@ -8,21 +8,9 @@ module.exports = {
 
     roll: function (args) {
         try {
-            // Check for only whitespace
-            //if (args.message.trim().length === 0){
-            //    return;
-            //}
 
             let messages = createRollMessages(args);
 
-//            for (let spec in rolls) {
-//                let data = rolls[spec];
-//                let total = data.reduce(function (tot, num) {
-//                    return tot + num;
-//                });
-//                lines.push(spec + ": " + data.join(" + ") + " = " + total);
-//            }
-//
             args.bot.sendMessage({
                 to: args.channelID,
                 message: messages.join("\n")
@@ -78,10 +66,10 @@ function rollResultMessage(spec, rolls){
     // spec['desc'] is the roll we are creating 
 
     // display messages:
-    // w2d10+1: 5, 7 => worst: 5  modified: 4
+    // w2d10+1: 5, 7 -> worst: 5  modified: 6
     // 2d6: 2 + 5 = 7
     // 2d10-1: 5 + 8 = 13 modified: 12
-    // b2d6: 2, 5 => best: 5
+    // b2d6: 2, 5 -> best: 5
 
 
     let total = rolls.reduce(function(tot, num) {
@@ -114,6 +102,11 @@ function rollResultMessage(spec, rolls){
         let modifier = Number(spec['modifier'] + spec['modAmount']);
         let modified = 0;
         modified = basevalue + modifier;
+
+        if (modified < 0 ){
+            modified = 0;
+        }
+
         message = message + ' modified: ' + modified;
     }
 
@@ -126,7 +119,8 @@ function rollSpecification(roll) {
 
     //create a specification of the dice roll
 
-    //a default die roll spec 1d6
+    //a default die roll spec 1d6 with no modifier and no worst/best option
+    
     let prefix = null;
     let numDie = 1;
     let dieSize = 6;
@@ -138,7 +132,7 @@ function rollSpecification(roll) {
     spec['numDie'] = numDie;
     spec['dieSize'] = dieSize;
     spec['modifier'] = modifier;
-    spec['modAmount'] = modAmount;
+    spec['modAmount'] = modAmount;  
     spec['desc'] = "";
 
     // Pattern for getting a single roll information;
@@ -146,7 +140,7 @@ function rollSpecification(roll) {
     // Can pick up a w or b as a prefix
     // can pick up or miss the first number(s) before  a "d" or "D" miss is default
     // can pick up or miss number(s) after a "d" or "D"  miss is default
-    // can pick up a modifier + or - as well as the amount 1 through 9
+    // can pick up a modifier + or - as well as the amount 0 through 9 
     
     let diePattern = /([wWbB])?(\d+)?[dD]+(\d+)?([+-])?(\d)?/;
     let rollInfo = [];
@@ -191,7 +185,7 @@ function rollSpecification(roll) {
 }
 
 function rollDice(numDie, dieSize) {
-    // the number of die (dice) to roll(numDie) that are of the same size (dieSize)
+    // the number of dice to roll <numDie> that are of the same size <dieSize>
     
     let rolls = [];
 

--- a/src/bot-command-handlers.js
+++ b/src/bot-command-handlers.js
@@ -9,24 +9,23 @@ module.exports = {
     roll: function (args) {
         try {
             // Check for only whitespace
-            if (args.message.trim().length === 0){
-                return;
-            }
+            //if (args.message.trim().length === 0){
+            //    return;
+            //}
 
-            let rolls = rollDice(args);
-            let lines = [];
+            let messages = createRollMessages(args);
 
-            for (let spec in rolls) {
-                let data = rolls[spec];
-                let total = data.reduce(function (tot, num) {
-                    return tot + num;
-                });
-                lines.push(spec + ": " + data.join(" + ") + " = " + total);
-            }
-
+//            for (let spec in rolls) {
+//                let data = rolls[spec];
+//                let total = data.reduce(function (tot, num) {
+//                    return tot + num;
+//                });
+//                lines.push(spec + ": " + data.join(" + ") + " = " + total);
+//            }
+//
             args.bot.sendMessage({
                 to: args.channelID,
-                message: lines.join("\n")
+                message: messages.join("\n")
             });
 
         } catch (e) {
@@ -41,36 +40,171 @@ module.exports = {
     },
 };
 
-function rollDice(args) {
-    let rolls = {};
-    let specs = args.message.split(/[ ,]+/);  // split by comma or whitespace
 
-    if (args.message !== "") {
-        // Loop through the dice specification
-        for (let i = 0; i < specs.length; i++) {
-            let total = 0;
-            let internalRolls = [];
-            let parts = specs[i].split(/[dD]+/);
-            let numDie = parts[0] ? parts[0] : "1";
-            let dieSize = parts[1];
+function createRollMessages(args){
 
-            for (let j = 0; j < numDie; j++) {
-                if (dieSize < 1) {
-                    internalRolls.push(0);
-                } else if (dieSize < 2) {
-                    internalRolls.push(1);
-                    total += 1;
-                } else {
-                    let roll = Math.floor(Math.random() * dieSize) + 1;
-                    internalRolls.push(roll);
-                    total += roll;
-                }
-            }
+    let messages = [];
 
-            rolls[specs[i]] = internalRolls;
-        }
+    let separateDieRolls = args.message.split(/[ ,]+/); // split by comma or whitespace
+
+    // create a default specification roll if nothing sent to us
+
+    if (separateDieRolls.length === 0) {
+        let spec = rollSpecification('');
+        let rollResults = rollDice(spec['numDie'], spec['dieSize']);
+        let message = rollResultMessage(spec, rolllResults);
+
+        messages.push(message);
     }
 
+    // loop through all the separate dice rolls
+    for (let i = 0; i < separateDieRolls.length; i++) {
+    
+        let spec = rollSpecification(separateDieRolls[i]);
+        let rollResults = rollDice(spec['numDie'], spec['dieSize']);
+        let message = rollResultMessage(spec, rollResults); 
+
+        messages.push(message);
+    }
+
+    return messages;
+}
+
+function rollResultMessage(spec, rolls){
+  
+    let message = spec['desc'] + ': ';
+    // create the result of the roll on one line
+    // outcomes can be total, best, worst with possibility of modifier  
+    // spec['desc'] is the roll we are creating 
+
+    // display messages:
+    // w2d10+1: 5, 7 => worst: 5  modified: 4
+    // 2d6: 2 + 5 = 7
+    // 2d10-1: 5 + 8 = 13 modified: 12
+    // b2d6: 2, 5 => best: 5
+
+
+    let total = rolls.reduce(function(tot, num) {
+        return tot + num;
+    });
+
+    let best = Math.max.apply(null, rolls);
+    let worst = Math.min.apply(null, rolls);
+    let basevalue = 0;
+
+    if (spec['prefix'] === 'w' || spec['prefix'] === 'b') {
+        message = message + rolls.join(', ') + ' -> ';
+        if (spec['prefix'] === 'b'){
+            message = message + 'best: ' + best;
+            basevalue = best;
+        }
+        else {
+            message = message + 'worst: ' + worst;
+            basevalue = worst;
+        }
+    }
+    else {  // total is the default
+        message = message + rolls.join (' + ') + ' = ' + total;
+        basevalue = total;
+    }
+   
+    // create modified value if required
+
+    if (spec['modAmount'] > 0) {
+        let modifier = Number(spec['modifier'] + spec['modAmount']);
+        let modified = 0;
+        modified = basevalue + modifier;
+        message = message + ' modified: ' + modified;
+    }
+
+    return message;
+
+}
+
+
+function rollSpecification(roll) {
+
+    //create a specification of the dice roll
+
+    //a default die roll spec 1d6
+    let prefix = null;
+    let numDie = 1;
+    let dieSize = 6;
+    let modifier = null;
+    let modAmount = 0;
+
+    let spec = {};
+    spec['prefix'] = prefix;
+    spec['numDie'] = numDie;
+    spec['dieSize'] = dieSize;
+    spec['modifier'] = modifier;
+    spec['modAmount'] = modAmount;
+    spec['desc'] = "";
+
+    // Pattern for getting a single roll information;
+    // Default is 1d6
+    // Can pick up a w or b as a prefix
+    // can pick up or miss the first number(s) before  a "d" or "D" miss is default
+    // can pick up or miss number(s) after a "d" or "D"  miss is default
+    // can pick up a modifier + or - as well as the amount 1 through 9
+    
+    let diePattern = /([wWbB])?(\d+)?[dD]+(\d+)?([+-])?(\d)?/;
+    let rollInfo = [];
+
+    // Create a default spec for just a blank roll
+    
+    if (roll !== '') {
+       rollInfo = diePattern.exec(roll);
+    }
+   
+    if (rollInfo.length > 1 ) {
+
+        spec['prefix'] = (typeof rollInfo[1] != 'undefined') ? rollInfo[1].toLowerCase() : prefix;
+
+        spec['numDie'] = (typeof rollInfo[2] != 'undefined') ? rollInfo[2] : numDie;
+
+        spec['dieSize'] = (typeof rollInfo[3] != 'undefined') ? rollInfo[3] : dieSize;
+
+        spec['modifier'] = (typeof rollInfo[4] != 'undefined') ? rollInfo[4] : modifier;
+
+        spec['modAmount'] = (typeof rollInfo[5] != 'undefined') ? rollInfo[5] : modAmount;
+    }
+
+
+    // put the description of the roll together
+
+    if (spec['prefix'] !== null) {
+        spec['desc'] = spec['prefix'] + '[';
+    }
+
+    spec['desc'] = spec['desc'] + spec['numDie'] + 'd' + spec['dieSize'];
+
+    if (spec['prefix'] !== null){
+        spec['desc'] = spec['desc'] + ']';
+    }
+
+    if (spec['modAmount'] > 0 ) {
+        spec['desc'] = spec['desc'] + spec['modifier'] + spec['modAmount'];
+    }
+
+    return spec;
+}
+
+function rollDice(numDie, dieSize) {
+    // the number of die (dice) to roll(numDie) that are of the same size (dieSize)
+    
+    let rolls = [];
+
+    for (let j = 0; j < numDie; j++) {
+        if (dieSize < 1) {
+            rolls.push(0);
+        } else if (dieSize < 2) {
+            rolls.push(1);
+        } else {
+            let roll = Math.floor(Math.random() * dieSize) + 1;
+            rolls.push(roll);
+        }
+    }
     return rolls;
 }
 

--- a/src/bot-command-handlers.js
+++ b/src/bot-command-handlers.js
@@ -28,21 +28,23 @@ module.exports = {
     },
 };
 
-
 function createRollMessages(args){
 
     let messages = [];
 
-    let separateDieRolls = args.message.split(/[ ,]+/); // split by comma or whitespace
+    let separateDieRolls = []
 
     // create a default specification roll if nothing sent to us
 
-    if (separateDieRolls.length === 0) {
+    if (args.message.trim().length === 0) {
         let spec = rollSpecification('');
         let rollResults = rollDice(spec['numDie'], spec['dieSize']);
-        let message = rollResultMessage(spec, rolllResults);
+        let message = rollResultMessage(spec, rollResults);
 
         messages.push(message);
+    }
+    else {
+        separateDieRolls = args.message.split(/[ ,]+/); // split by comma or whitespace
     }
 
     // loop through all the separate dice rolls
@@ -78,22 +80,22 @@ function rollResultMessage(spec, rolls){
 
     let best = Math.max.apply(null, rolls);
     let worst = Math.min.apply(null, rolls);
-    let basevalue = 0;
+    let baseValue = 0;
 
     if (spec['prefix'] === 'w' || spec['prefix'] === 'b') {
         message = message + rolls.join(', ') + ' -> ';
         if (spec['prefix'] === 'b'){
             message = message + 'best: ' + best;
-            basevalue = best;
+            baseValue = best;
         }
         else {
             message = message + 'worst: ' + worst;
-            basevalue = worst;
+            baseValue = worst;
         }
     }
     else {  // total is the default
         message = message + rolls.join (' + ') + ' = ' + total;
-        basevalue = total;
+        baseValue = total;
     }
    
     // create modified value if required
@@ -101,7 +103,7 @@ function rollResultMessage(spec, rolls){
     if (spec['modAmount'] > 0) {
         let modifier = Number(spec['modifier'] + spec['modAmount']);
         let modified = 0;
-        modified = basevalue + modifier;
+        modified = baseValue + modifier;
 
         if (modified < 0 ){
             modified = 0;

--- a/src/bot-command-handlers.spec.js
+++ b/src/bot-command-handlers.spec.js
@@ -141,7 +141,7 @@ describe("bot-command-handlers", function() {
             assert.equal(callArgs.message, "2d1: 1 + 1 = 2");
         });
 
-        it("Should do nothing with empty arguments", function() {
+        it("Should default to 1d6 roll with empty arguments", function() {
             // Arrange
             let sendMessageStub = this.sandbox.stub();
             let bot = {
@@ -163,6 +163,9 @@ describe("bot-command-handlers", function() {
 
             // Assert
             assert(!sendMessageStub.called);
+            let callArgs = sendMessageStub.getCall(0).args[0];
+            assert.equal(callArgs.to, 3456);
+            assert.equal(callArgs.message, "1d6: 2 = 2");
         });
 
         it("Should assume one when number of die not specified", function() {
@@ -189,7 +192,145 @@ describe("bot-command-handlers", function() {
             assert(sendMessageStub.called);
             let callArgs = sendMessageStub.getCall(0).args[0];
             assert.equal(callArgs.to, 3456);
-            assert.equal(callArgs.message, "d6: 2 = 2");
+            assert.equal(callArgs.message, "1d6: 2 = 2");
         });
+
+        it("Should assume 6 when die type not specified", function() {
+            // Arrange
+            let sendMessageStub = this.sandbox.stub();
+            let bot = {
+                sendMessage: sendMessageStub
+            };
+            let randomStub = this.sandbox.stub(Math, "random");
+            randomStub.onCall(0).returns(0.233238);
+            randomStub.onCall(1).returns(0.746827);
+
+            // Act
+            let args = {
+                bot: bot,
+                user: "TestUser",
+                userID: 1234,
+                channelID: 3456,
+                message: "2d"
+            };
+            handlers.roll(args);
+
+            // Assert
+            assert(sendMessageStub.called);
+            let callArgs = sendMessageStub.getCall(0).args[0];
+            assert.equal(callArgs.to, 3456);
+            assert.equal(callArgs.message, "2d6: 2 + 5 = 7");
+        });
+
+        it("Should emit correctly when worst scenario specified", function() {
+            // Arrange
+            let sendMessageStub = this.sandbox.stub();
+            let bot = {
+                sendMessage: sendMessageStub
+            };
+            let randomStub = this.sandbox.stub(Math, "random");
+            randomStub.onCall(0).returns(0.937548);
+            randomStub.onCall(1).returns(0.304728);
+
+            // Act
+            let args = {
+                bot: bot,
+                user: "TestUser",
+                userID: 1234,
+                channelID: 3456,
+                message: "w2d10"
+            };
+            handlers.roll(args);
+
+            // Assert
+            assert(sendMessageStub.called);
+            let callArgs = sendMessageStub.getCall(0).args[0];
+            assert.equal(callArgs.to, 3456);
+            assert.equal(callArgs.message, "w[2d10]: 10, 4 -> worst: 4");
+        });
+
+        it("Should emit correctly when best scenario specified", function() {
+            // Arrange
+            let sendMessageStub = this.sandbox.stub();
+            let bot = {
+                sendMessage: sendMessageStub
+            };
+            let randomStub = this.sandbox.stub(Math, "random");
+            randomStub.onCall(0).returns(0.937548);
+            randomStub.onCall(1).returns(0.304728);
+
+            // Act
+            let args = {
+                bot: bot,
+                user: "TestUser",
+                userID: 1234,
+                channelID: 3456,
+                message: "b2d10"
+            };
+            handlers.roll(args);
+
+            // Assert
+            assert(sendMessageStub.called);
+            let callArgs = sendMessageStub.getCall(0).args[0];
+            assert.equal(callArgs.to, 3456);
+            assert.equal(callArgs.message, "b[2d10]: 10, 4 -> best: 10");
+        });
+
+        it("Should emit correctly when modifier is specified", function() {
+            // Arrange
+            let sendMessageStub = this.sandbox.stub();
+            let bot = {
+                sendMessage: sendMessageStub
+            };
+            let randomStub = this.sandbox.stub(Math, "random");
+            randomStub.onCall(0).returns(0.937548);
+            randomStub.onCall(1).returns(0.304728);
+
+            // Act
+            let args = {
+                bot: bot,
+                user: "TestUser",
+                userID: 1234,
+                channelID: 3456,
+                message: "2d10+2"
+            };
+            handlers.roll(args);
+
+            // Assert
+            assert(sendMessageStub.called);
+            let callArgs = sendMessageStub.getCall(0).args[0];
+            assert.equal(callArgs.to, 3456);
+            assert.equal(callArgs.message, "2d10+2: 10 + 4 = 14 modified: 16");
+        });
+
+        it("Should emit correctly when modifier is below 0", function() {
+            // Arrange
+            let sendMessageStub = this.sandbox.stub();
+            let bot = {
+                sendMessage: sendMessageStub
+            };
+            let randomStub = this.sandbox.stub(Math, "random");
+            randomStub.onCall(0).returns(0.233238);
+            randomStub.onCall(1).returns(0.746827);
+
+            // Act
+            let args = {
+                bot: bot,
+                user: "TestUser",
+                userID: 1234,
+                channelID: 3456,
+                message: "w2d6-3"
+            };
+            handlers.roll(args);
+
+            // Assert
+            assert(sendMessageStub.called);
+            let callArgs = sendMessageStub.getCall(0).args[0];
+            assert.equal(callArgs.to, 3456);
+            assert.equal(callArgs.message, "w[2d6]-3: 2, 5 -> worst: 2 modified: 0");
+        });
+
+
+ 
     });
 });

--- a/src/bot-command-handlers.spec.js
+++ b/src/bot-command-handlers.spec.js
@@ -162,7 +162,7 @@ describe("bot-command-handlers", function() {
             handlers.roll(args);
 
             // Assert
-            assert(!sendMessageStub.called);
+            assert(sendMessageStub.called);
             let callArgs = sendMessageStub.getCall(0).args[0];
             assert.equal(callArgs.to, 3456);
             assert.equal(callArgs.message, "1d6: 2 = 2");


### PR DESCRIPTION
### Issue ###

Increase the features of roll logic to handle best, worst and apply modifier messages.

### Summary ###

Added createRollMessages --- main call to create the resulting messages from all the rolls supplied to the roll command.

Added rollSpecification --- uses a regex to parse a roll and create a specification for that roll. Is configured to a default in case no roll supplied. The spec is the roll information along with if best or worst is set as well as if any modifier is set.

Added rollResultMessage --- create the result message of a single roll specification, default is calculating the sum total of the die rolls. Creates the total, best, worst, and modified dice roll message based on the specification. 

Cleaned up rollDice --- removed the total calculations, just outputs rolls in an array now

### Testing ###

No bot testing completed.

Results from createRollMessages are tested for correct input. 

Example rolls
Which can be <empty string>, 2d, w2D10, b2d20-1, 2d-2, d100
<empty string> = random roll of 1d6 output
2d = random 2 rolls of d6 output as total result
w2D10 = random 2 rolls of d10 output the worst (lowest) value
b2d20-1 = random 2 rolls of d20 output the best (highest) value that is then modified by -1
2d-2 = random 2 rolls of d6 as total result that is modified by -2
d100 = random 1 roll of d100 as total result



